### PR TITLE
Remove trailing space from keywords

### DIFF
--- a/pack/ml.json
+++ b/pack/ml.json
@@ -45,7 +45,7 @@
         "faction_cost": 1,
         "flavor": "Her ability to analyze and adapt mid-run bordered on the paranormal.",
         "illustrator": "Hannah Christensen",
-        "keywords": "Run - Stealth ",
+        "keywords": "Run - Stealth",
         "pack_code": "ml",
         "position": 83,
         "quantity": 3,


### PR DESCRIPTION
On netrunnerdb.com, there are two "Stealth" entries in the "Subtype" search field. I'm guessing this is why.